### PR TITLE
ci: update test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,14 +24,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version:
           - '3.12'
           - '3.11'
           - '3.10'
           - '3.9'
           - '3.8'
-          - '3.7'
         pyopenssl: [0, 1]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
## Summary
- run tests on macOS latest instead of macOS 13
- drop Python 3.7 from test matrix
- ensure Python 3.8-3.12 run across Ubuntu, macOS, and Windows

## Testing
- `pytest -q --maxfail=1` *(fails: ModuleNotFoundError: No module named 'rich')*


------
https://chatgpt.com/codex/tasks/task_e_68938565ac908326ba86619d8f31de56