### PR TITLE
Update werkzeug and pytest-httpbin deps

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -81,10 +81,10 @@ console_scripts =
 [options.extras_require]
 dev =
     pytest
-    pytest-httpbin>=0.0.6
+    pytest-httpbin>=1.0.0
     responses
     pytest-mock
-    werkzeug<2.1.0
+    werkzeug>=3.0,<4
     flake8
     flake8-comprehensions
     flake8-deprecated
@@ -98,10 +98,10 @@ dev =
     Jinja2
 test =
     pytest
-    pytest-httpbin>=0.0.6
+    pytest-httpbin>=1.0.0
     responses
     pytest-mock
-    werkzeug<2.1.0
+    werkzeug>=3.0,<4
 
 [options.data_files]
 share/man/man1 =


### PR DESCRIPTION
## Summary
- relax werkzeug requirement to >=3.0,<4
- bump pytest-httpbin to >=1.0.0 for compatibility

## Testing
- `pip install -e '.[dev,test]'`
- `pytest -q` *(fails: 19 failed, 1001 passed)*


------
https://chatgpt.com/codex/tasks/task_e_68938609e0d88326bca6e49abe72be75